### PR TITLE
Fix Voicelines API

### DIFF
--- a/src/core/CacheUpdater.ts
+++ b/src/core/CacheUpdater.ts
@@ -28,8 +28,23 @@ export default class Updater {
       if (updates.length > 0) {
         this.client.emit('updateAvalible', updates);
         return Promise.all(updates.map(async (type) => {
-          let raw = Object.values(JSON.parse(await fetch(data[type])) || []);
-          this.client.set(type, raw);
+
+          let raw = JSON.parse(await fetch(data[type])) ?? [];
+
+          if (type === 'voicelines') {
+            let mappedVls: Record<string, any>[] = [];
+            for (const [shipId, voicelines] of Object.entries(raw)) { // loop through Voiceline[]
+              //@ts-ignore
+              voicelines['id'] = shipId;
+              //@ts-ignore
+              mappedVls.push(voicelines);
+            }
+
+            this.client.set('voicelines', mappedVls);
+          } else {
+
+            this.client.set(type, raw);
+          }
           fs.writeFileSync(local[type], JSON.stringify(raw));
         }));
       }

--- a/src/core/CacheUpdater.ts
+++ b/src/core/CacheUpdater.ts
@@ -29,11 +29,15 @@ export default class Updater {
         this.client.emit('updateAvalible', updates);
         return Promise.all(updates.map(async (type) => {
 
-          let raw = JSON.parse(await fetch(data[type])) ?? [];
+          const raw = JSON.parse(await fetch(data[type])) ?? [];
 
           if (type === 'voicelines') {
+            /**
+             * Voice lines have to be massaged.
+             * We set the ship's ID as a property of each Voiceline.
+             */
             let mappedVls: Record<string, any>[] = [];
-            for (const [shipId, voicelines] of Object.entries(raw)) { // loop through Voiceline[]
+            for (const [shipId, voicelines] of Object.entries(raw)) {
               //@ts-ignore
               voicelines['id'] = shipId;
               //@ts-ignore
@@ -42,7 +46,6 @@ export default class Updater {
 
             this.client.set('voicelines', mappedVls);
           } else {
-
             this.client.set(type, raw);
           }
           fs.writeFileSync(local[type], JSON.stringify(raw));

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -86,4 +86,10 @@ export class AzurAPI extends EventEmitter {
   queryIsShipName(query: string) {
     return this.ships.name(query.toUpperCase()).length !== 0;
   }
+  /**
+   * Another bodge...
+   */
+  getShipIdByName(name: string){
+    return this.ships.getShipIdByName(name);
+  }
 }

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -84,7 +84,7 @@ export class AzurAPI extends EventEmitter {
    * query string matches a ship's name.
    */
   queryIsShipName(query: string) {
-    return this.ships.name(query.toUpperCase()).length !== 0;
+    return this.ships.name(query).length !== 0;
   }
   /**
    * Another bodge...

--- a/src/core/api/api_ship.ts
+++ b/src/core/api/api_ship.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 import { Ship } from '../../types/ship';
-import API, { Language, normalize, NATIONS, advancedOptions } from './api';
+import API, { Language, normalize, NATIONS, advancedOptions, normalizeCompare } from './api';
 import { AzurAPI } from '../Client';
 
 /**
@@ -16,7 +16,14 @@ export class Ships extends API<Ship> {
    * @param client An AzurAPI instance
    */
   constructor(client: AzurAPI) {
-    super(client, ['names.en', 'names.cn', 'names.jp', 'names.kr', 'names.code', 'id']);
+    super(client, [
+      'names.en',
+      'names.cn',
+      'names.jp',
+      'names.kr',
+      'names.code',
+      'id',
+    ]);
   }
 
   /**
@@ -24,7 +31,9 @@ export class Ships extends API<Ship> {
    * @param id String of number
    */
   id(id: string): Ship | undefined {
-    for (let item of this.raw) if (normalize(item.id.toUpperCase()) === normalize(id.toUpperCase())) return item;
+    for (let item of this.raw)
+      if (normalize(item.id.toUpperCase()) === normalize(id.toUpperCase()))
+        return item;
     return undefined;
   }
 
@@ -33,8 +42,18 @@ export class Ships extends API<Ship> {
    * @param name Ship name
    * @param languages Language to search
    */
-  name(name: string, languages: Language[] = ['en', 'cn', 'jp', 'kr']): Ship[] | [] {
-    return this.raw.filter(ship => languages.some(lang => ship.names[lang] && normalize(ship.names[lang].toUpperCase()) === normalize(name.toUpperCase())));
+  name(
+    name: string,
+    languages: Language[] = ['en', 'cn', 'jp', 'kr']
+  ): Ship[] | [] {
+    return this.raw.filter((ship) =>
+      languages.some(
+        (lang) =>
+          ship.names[lang] &&
+          normalize(ship.names[lang].toUpperCase()) ===
+            normalize(name.toUpperCase())
+      )
+    );
   }
 
   /**
@@ -42,9 +61,14 @@ export class Ships extends API<Ship> {
    * @param hull Hull name
    */
   hull(hull: string): Ship[] | [] {
-    return this.raw.filter(ship =>
-      (ship.hullType && normalize(ship.hullType.toUpperCase()) === normalize(hull.toUpperCase())) ||
-        (ship.retrofitHullType && normalize(ship.retrofitHullType.toUpperCase()) === normalize(hull.toUpperCase()))
+    return this.raw.filter(
+      (ship) =>
+        (ship.hullType &&
+          normalize(ship.hullType.toUpperCase()) ===
+            normalize(hull.toUpperCase())) ||
+        (ship.retrofitHullType &&
+          normalize(ship.retrofitHullType.toUpperCase()) ===
+            normalize(hull.toUpperCase()))
     );
   }
 
@@ -54,8 +78,16 @@ export class Ships extends API<Ship> {
    */
   nationality(nationality: string): Ship[] | [] {
     let results: Ship[] = [];
-    nationality = Object.keys(NATIONS).find(key => NATIONS[key].includes(nationality.toLowerCase())) || nationality;
-    for (let ship of this.raw) if (normalize(ship.nationality.toUpperCase()) === normalize(nationality.toUpperCase())) results.push(ship);
+    nationality =
+      Object.keys(NATIONS).find((key) =>
+        NATIONS[key].includes(nationality.toLowerCase())
+      ) || nationality;
+    for (let ship of this.raw)
+      if (
+        normalize(ship.nationality.toUpperCase()) ===
+        normalize(nationality.toUpperCase())
+      )
+        results.push(ship);
     return results;
   }
 
@@ -64,8 +96,14 @@ export class Ships extends API<Ship> {
    * @param query Ship name in any language or ship id
    */
   get(query: string): Ship | Ship[] {
-    let fuzeResult = this.fuze(query).sort((a, b) => (b.score || 0) - (a.score || 0))[0];
-    return this.id(query) || this.name(query)[0] || (fuzeResult ? fuzeResult.item : undefined);
+    let fuzeResult = this.fuze(query).sort(
+      (a, b) => (b.score || 0) - (a.score || 0)
+    )[0];
+    return (
+      this.id(query) ||
+      this.name(query)[0] ||
+      (fuzeResult ? fuzeResult.item : undefined)
+    );
   }
 
   /**
@@ -75,10 +113,21 @@ export class Ships extends API<Ship> {
   all(query: string): Ship[] | [] {
     let results: (Ship | undefined)[] = [];
     results.push(this.id(query));
-    results.push(...this.name(query).filter(i => i));
-    results.push(...this.fuze(query).map(i => i.item));
+    results.push(...this.name(query).filter((i) => i));
+    results.push(...this.fuze(query).map((i) => i.item));
     return results
-      .filter((value: Ship | undefined): value is Ship => value !== null && value !== undefined)
-      .filter((elem, index, self) => index === self.findIndex(el => el.id === elem.id));
+      .filter(
+        (value: Ship | undefined): value is Ship =>
+          value !== null && value !== undefined
+      )
+      .filter(
+        (elem, index, self) =>
+          index === self.findIndex((el) => el.id === elem.id)
+      );
   }
+  getShipIdByName(name: string, language = 'en') {
+    return this.name(name)[0].id;
+  }
+
 }
+

--- a/src/core/api/api_ship.ts
+++ b/src/core/api/api_ship.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 import { Ship } from '../../types/ship';
-import API, { Language, normalize, NATIONS, advancedOptions, normalizeCompare } from './api';
+import API, { Language, normalize, NATIONS, advancedOptions } from './api';
 import { AzurAPI } from '../Client';
 
 /**

--- a/src/core/api/api_voiceline.ts
+++ b/src/core/api/api_voiceline.ts
@@ -19,12 +19,16 @@ export class Voicelines extends API<Voiceline> {
     super(client);
   }
 
-  get(shipName: string) {
-    if (!this.client.queryIsShipName(shipName)) {
-      throw new Error("Must use ship name to get voice lines.");
+  get(shipNameOrId: string) {
+    if (this.client.queryIsShipName(shipNameOrId)) {
+      const id = this.client.getShipIdByName(shipNameOrId);
+      return this.raw.filter((vl) => vl.id === id)[0];
     }
-    const id = this.client.getShipIdByName(shipName);
+    const vlsForId = this.raw.filter((vl) => vl.id === shipNameOrId);
+    if (vlsForId.length === 0) {
+      throw new Error("Must use ship name or ID to get voice lines.");
+    }
 
-    return this.raw.filter((vl) => vl.id === id);
+    return vlsForId[0];
   }
 }

--- a/src/core/api/api_voiceline.ts
+++ b/src/core/api/api_voiceline.ts
@@ -27,7 +27,28 @@ export class Voicelines extends API<Voiceline> {
   //   }
   //   return undefined;
   // }
-  line(line: string, languages: Language[] = ['en', 'cn', 'jp', 'kr']): Voiceline[] | [] {
-    return this.raw.filter(ship => languages.some(lang => ship.names[lang] && normalize(ship.names[lang].toUpperCase()) === normalize(line.toUpperCase())));
+
+  get(shipName: string) {
+    if (!this.client.queryIsShipName(shipName)) {
+      throw new Error('Must use ship name to get voice lines.');
+    }
+    const id = this.client.getShipIdByName(shipName);
+    // console.log(this.raw);
+    // const reverse = [...this.raw].reverse();
+    // console.log(reverse[id]);
+    return this.raw.filter((vl) => vl.id === id);
   }
+  // line(
+  //   line: string,
+  //   languages: Language[] = ["en", "cn", "jp", "kr"]
+  // ): Voiceline[] | [] {
+  //   return this.raw.filter((ship) =>
+  //     languages.some(
+  //       (lang) =>
+  //         ship.names[lang] &&
+  //         normalize(ship.names[lang].toUpperCase()) ===
+  //           normalize(line.toUpperCase())
+  //     )
+  //   );
+  // }
 }

--- a/src/core/api/api_voiceline.ts
+++ b/src/core/api/api_voiceline.ts
@@ -3,9 +3,9 @@
  * Extended voicelines api functions
  * @packageDocumentation
  */
-import { Voiceline } from '../../types/voiceline';
-import API, { normalize, Language } from './api';
-import { AzurAPI } from '../Client';
+import { Voiceline } from "../../types/voiceline";
+import API, { normalize, Language } from "./api";
+import { AzurAPI } from "../Client";
 
 /**
  * Special voicelines class for extended functionality
@@ -19,36 +19,12 @@ export class Voicelines extends API<Voiceline> {
     super(client);
   }
 
-  // id(id: string): Voiceline | undefined {
-  //   for (let item of this.raw) {
-  //     for (let type of Object.values(item)) {
-  //       for (let sub of type) if (normalize(sub.event.toUpperCase()) === normalize(id.toUpperCase())) return item;
-  //     }
-  //   }
-  //   return undefined;
-  // }
-
   get(shipName: string) {
     if (!this.client.queryIsShipName(shipName)) {
-      throw new Error('Must use ship name to get voice lines.');
+      throw new Error("Must use ship name to get voice lines.");
     }
     const id = this.client.getShipIdByName(shipName);
-    // console.log(this.raw);
-    // const reverse = [...this.raw].reverse();
-    // console.log(reverse[id]);
+
     return this.raw.filter((vl) => vl.id === id);
   }
-  // line(
-  //   line: string,
-  //   languages: Language[] = ["en", "cn", "jp", "kr"]
-  // ): Voiceline[] | [] {
-  //   return this.raw.filter((ship) =>
-  //     languages.some(
-  //       (lang) =>
-  //         ship.names[lang] &&
-  //         normalize(ship.names[lang].toUpperCase()) ===
-  //           normalize(line.toUpperCase())
-  //     )
-  //   );
-  // }
 }

--- a/src/types/voiceline.ts
+++ b/src/types/voiceline.ts
@@ -4,16 +4,19 @@
  * @packageDocumentation
  */
 
-export interface Voiceline {
-    Default: Line[];
-    Retrofit: Line[];
-    [key: string]: Line[]
+export type Voiceline = VoicelineData & {
+  id: string;
 }
 
+interface VoicelineData {
+  Default: Line[];
+  Retrofit: Line[];
+  [key: string]: Line[]
+}
 interface Line {
-    event: string;
-    en?: string;
-    zh?: string;
-    jp?: string;
-    audio?: string;
+  event: string;
+  en?: string;
+  zh?: string;
+  jp?: string;
+  audio?: string;
 }


### PR DESCRIPTION
This removes the `lines()` function from the Voicelines API and replaces it with the more conventional `get()`.
You can pass `get()` an ID or shipname, as specified in the tests. 

Please note the data massaging done in `CacheUpdater.ts`. Data-formatting *probably* need to be done in `azurapi-js-setup`, but that would affect clients fetching the json file from Github – just planting seeds for discussion.

Also, note that `api_ships.ts` only has a substantial change at line 128. I just formatted the file by accident. Sorry.