### PR TITLE
Add `.internal` file handling from the setup repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.1.2",
       "license": "GPL-3.0",
       "dependencies": {
-        "fuse.js": "^6.4.6"
+        "fuse.js": "^6.4.6",
+        "node-fetch": "^2.6.7"
       },
       "devDependencies": {
         "@augu/eslint-config": "^2.2.0",
         "@types/jest": "^26.0.14",
         "@types/node": "^14.14.45",
+        "@types/node-fetch": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
@@ -1900,6 +1902,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
       "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
       "dev": true
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7326,6 +7338,44 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11417,6 +11467,16 @@
       "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -15457,6 +15517,35 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc --watch",
     "test": "jest --config jest.config.js",
     "lint": "eslint src --ext .ts --fix",
     "build": "npm run lint && npm run compile && npm run build:browser && npm run build:docs && npm run build:docs.json && npm run test",
@@ -38,12 +38,14 @@
   },
   "homepage": "https://github.com/AzurAPI/azurapi-js#readme",
   "dependencies": {
-    "fuse.js": "^6.4.6"
+    "fuse.js": "^6.4.6",
+    "node-fetch": "^2.6.7"
   },
   "devDependencies": {
     "@augu/eslint-config": "^2.2.0",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.14.45",
+    "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",

--- a/src/core/Data.ts
+++ b/src/core/Data.ts
@@ -5,17 +5,27 @@
  */
 import { join } from 'path';
 
-export const data = {
-  version: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/version.json',
-  ships: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/ships.json',
-  equipments:
-    'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/equipments.json',
-  chapters:
-    'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/chapters.min.json',
-  voicelines: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/voice_lines.json',
-  barrages: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/barrage.json',
-  shipList: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/ship-list.json',
-  idMap: 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master/dist/id-map.json',
+const baseDataUrl = 'https://raw.githubusercontent.com/AzurAPI/azurapi-js-setup/master';
+
+export type datatype = 'ships' | 'equipments' | 'voicelines' | 'chapters' | 'barrages';
+
+type UrlType = datatype | 'version' | 'shipList' | 'idMap';
+
+export const getDataUrl = (type: UrlType, options?: { internal?: boolean }) => {
+  const internalString = options?.internal ? '.internal' : '';
+
+  const urls: Record<UrlType, string> = {
+    version: `${baseDataUrl}/dist/version${internalString}.json`,
+    ships: `${baseDataUrl}/dist/ships${internalString}.json`,
+    equipments: `${baseDataUrl}/dist/equipments${internalString}.json`,
+    chapters: `${baseDataUrl}/dist/chapters${internalString}.min.json`,
+    voicelines: `${baseDataUrl}/voice_lines${internalString}.json`,
+    barrages: `${baseDataUrl}/dist/barrage${internalString}.json`,
+    shipList: `${baseDataUrl}/dist/ship-list${internalString}.json`,
+    idMap: `${baseDataUrl}/dist/id-map${internalString}.json`,
+  };
+
+  return urls[type];
 };
 
 export const local = {
@@ -27,9 +37,7 @@ export const local = {
   shipList: join(__dirname, '..', '.azurlane', 'ship-list.json'),
   idMap: join(__dirname, '..', '.azurlane', 'id-map.json'),
 };
-export type datatype = 'ships' | 'equipments' | 'voicelines' | 'chapters' | 'barrages';
 export let baseFolder = join(__dirname, '..', '.azurlane');
 export let versionInfo = join(__dirname, '..', '.azurlane', 'version.json');
 
 Object.freeze(local);
-Object.freeze(data);

--- a/src/core/UpdateChecker.ts
+++ b/src/core/UpdateChecker.ts
@@ -3,9 +3,9 @@
  * Check for updates and functions relating to updates
  * @packageDocumentation
  */
-import { data, datatype, versionInfo } from './Data';
+import { datatype, versionInfo, getDataUrl } from './Data';
 import fs from 'fs';
-import https from 'https';
+import fetch from 'node-fetch';
 
 const supported = ['ships', 'equipments', 'chapters', 'barrages', 'voicelines'];
 
@@ -18,7 +18,8 @@ let remote;
 export async function check(): Promise<datatype[]> {
   if (!version && fs.existsSync(versionInfo))
     version = JSON.parse(fs.readFileSync(versionInfo).toString());
-  remote = JSON.parse(await fetch(data.version));
+  const response = await fetch(getDataUrl('version'));
+  remote = await response.json();
   let needUpdate: datatype[] = [];
   for (let type of supported)
     if (
@@ -37,20 +38,4 @@ export async function check(): Promise<datatype[]> {
  */
 export function save() {
   if (remote) fs.writeFileSync(versionInfo, JSON.stringify((version = remote)));
-}
-
-/**
- * Fetch data
- * @param url URL
- */
-export function fetch(url: string): Promise<string> {
-  return new Promise((resolve, reject) =>
-    https
-      .get(url, (resp) => {
-        let data = '';
-        resp.on('data', (chunk) => (data += chunk));
-        resp.on('end', () => resolve(data));
-      })
-      .on('error', (err) => reject(err))
-  );
 }


### PR DESCRIPTION
Refactored the way data urls are obtained and added node-fetch to have access to the status of the request, so that the `.internal` version of a data file is tried in the case of the initial request returning a 404.

The PR is marked as draft as there seem to be some differences in the format of internal files compared to what normal files looked like, I assume, leading to the majority of the tests breaking, such as there being no "IJN" nationality, instead expecting "Sakura Empire". The data format is outside the scope of my knowledge, so someone else should most likely fix these compatibility issues.